### PR TITLE
fix: skip data backup

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -21,7 +21,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@any:routeadm" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.max-per-node=1" \
-    --label='org.nethserver.flags=core_module' \
+    --label='org.nethserver.flags=core_module no_data_backup' \
     --label="org.nethserver.images=quay.io/prometheus/prometheus:v3.2.0 quay.io/prometheus/alertmanager:v0.28.0 docker.io/grafana/grafana:11.5.2 ghcr.io/nethserver/alert-proxy:latest" \
     "${container}"
 # Commit the image


### PR DESCRIPTION
Exclude this module from data backup, like Ldapproxy and Netdata.