### PR TITLE
fix(alert-proxy): make sure env file is updated

### DIFF
--- a/imageroot/events/subscription-changed/10handler
+++ b/imageroot/events/subscription-changed/10handler
@@ -6,6 +6,5 @@
 #
 
 # reload the subscription configuration
-if systemctl --user -q is-active alert-proxy.service; then
-    systemctl --user restart alert-proxy.service
-fi
+write-alert-proxy-envfile
+systemctl --user restart alert-proxy.service


### PR DESCRIPTION
The Prometheus unit is the one that writes the env file for the alert-proxy service.
Since Prometheus is not restarted during subscription-changed event, the write-alert-proxy-envfile script must be called manually before restarting the alert-proxy service.