### PR TITLE
fix: enable/disable Grafana at boot

### DIFF
--- a/imageroot/actions/configure-module/80services
+++ b/imageroot/actions/configure-module/80services
@@ -9,7 +9,9 @@
 systemctl --user restart prometheus.service alertmanager.service alert-proxy.service
 
 if [ -n "$GRAFANA_PATH" ]; then
+    systemctl --user enable grafana.service
     systemctl --user restart grafana.service
 else
+    systemctl --user disable grafana.service
     systemctl --user stop grafana.service
 fi


### PR DESCRIPTION
The service is not started after a system reboot.


Refs NethServer/dev#7162