### PR TITLE
fix(grafana): set prometheus scrape interval

### DIFF
--- a/imageroot/bin/provision-grafana
+++ b/imageroot/bin/provision-grafana
@@ -26,6 +26,8 @@ with open('local.yml', 'w') as fp:
     fp.write('    uid: prometheus\n')
     fp.write('    access: proxy\n')
     fp.write(f'    url: http://cluster-leader:9091/{prometheus_path}\n')
+    fp.write('    jsonData:\n')
+    fp.write('      timeInterval: 1m\n')
 
     fp.write('  - name: Local Loki\n')
     fp.write('    type: loki\n')


### PR DESCRIPTION
Default scrape interval configured inside Grafana was 15s. With this configuration some charts, like the one of the CPU load, were empty when zooming in (but visible for 24h time frame). This configuration fixes the issue.