### PR TITLE
fix: distinct node_exporter and Loki alerts

### DIFF
--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -34,7 +34,7 @@ with open('rules.d/loki.yml', 'w') as f:
     expr: up{job="loki"} == 0
     for: 0m
     labels:
-      severity: critical
+      severity: warning
       node: ''' + os.getenv("NODE_ID") + '''
     annotations:
       summary: Loki instance {{ $labels.instance }} is down


### PR DESCRIPTION
If Loki goes offline do not raise a "node offline" alert. Instead, define a Loki-specific alert.

Refs NethServer/dev#7426