### PR TITLE
Mail_from can be empty to use the default sender address

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -29,7 +29,7 @@
         },
         "mail_from": {
             "description": "Email address used as sender for alerts. Either a valid email address or empty",
-	        "oneOf": [
+	    "oneOf": [
                 {
                     "type": "string",
                     "format": "email"

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -28,10 +28,19 @@
             "format": "string"
         },
         "mail_from": {
-            "type": "string",
-            "description": "Email address used as sender for alerts.",
-            "format": "email"
+            "description": "Email address used as sender for alerts. Either a valid email address or empty",
+	        "oneOf": [
+                {
+                    "type": "string",
+                    "format": "email"
+                },
+                {
+                    "type": "string",
+                    "maxLength": 0
+                }
+            ]
         },
+
         "mail_to": {
             "type": "array",
             "description": "Email addresses used as recipients for alerts.",

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -40,7 +40,6 @@
                 }
             ]
         },
-
         "mail_to": {
             "type": "array",
             "description": "Email addresses used as recipients for alerts.",


### PR DESCRIPTION
This pull request updates the validation schema for the `mail_from` field in `validate-input.json` to allow either a valid email address or an empty string (to use alertmanager@<node_fqdn>) .  The most important change is the introduction of a new `oneOf` condition to enforce this validation.

Validation schema update:

* [`imageroot/actions/configure-module/validate-input.json`](diffhunk://#diff-80e47dd0e511562f78795dea569226cfdedaf61a6e8535a1e5c0457ed3619eb0R31-R43): Updated the `mail_from` field to include a `oneOf` condition, allowing it to be either a valid email address or an empty string with a maximum length of 0.