### PR TITLE
feat(provisioning): provision on module-removed

### DIFF
--- a/imageroot/events/module-removed/15prometheus
+++ b/imageroot/events/module-removed/15prometheus
@@ -1,0 +1,1 @@
+../metrics-target-changed/15handler

--- a/imageroot/events/module-removed/20grafana
+++ b/imageroot/events/module-removed/20grafana
@@ -1,0 +1,1 @@
+../metrics-datasource-changed/15handler


### PR DESCRIPTION
When a module is removed, make sure to remove all dashboards associated to that module.