### PR TITLE
feat: TLS certificate expiration alerts

### DIFF
--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -110,8 +110,8 @@ with open('rules.d/tlscert.yml', 'w') as f:
     f.write(r'''groups:
 - name: TLS certificates
   rules:
-  - alert: certexpiring
-    expr: 21d < (traefik_tls_certs_not_after - time()) < 30d
+  - alert: certexp
+    expr: 7d <= (traefik_tls_certs_not_after - time()) < 28d
     for: 5m
     labels:
       severity: warning
@@ -119,10 +119,10 @@ with open('rules.d/tlscert.yml', 'w') as f:
       summary: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
       description: >
         The {{ $labels.module_id }} certificate {{ $labels.cn }} valid for {{ $labels.sans }}
-        on Node {{ $labels.node }} expires in less than 30 days. It must be renewed, or
+        on Node {{ $labels.node }} expires in less than 28 days. It must be renewed, or
         removed from the TLS certificates page.
-  - alert: certexpiring
-    expr: 0 < (traefik_tls_certs_not_after - time()) < 21d
+  - alert: certexp
+    expr: 0 < (traefik_tls_certs_not_after - time()) < 7d
     for: 5m
     labels:
       severity: critical
@@ -130,9 +130,9 @@ with open('rules.d/tlscert.yml', 'w') as f:
       summary: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
       description: >
         The {{ $labels.module_id }} certificate {{ $labels.cn }} valid for {{ $labels.sans }}
-        on Node {{ $labels.node }} expires in less than 21 days. It must be renewed, or
+        on Node {{ $labels.node }} expires in less than 7 days. It must be renewed, or
         removed from the TLS certificates page.
-  - alert: certexpired
+  - alert: certexp
     expr: (time() - traefik_tls_certs_not_after) > 0
     for: 5m
     labels:


### PR DESCRIPTION
Check expiration dates of Traefik's certificates. This new alert group requires Traefik 3.5+.


Refs NethServer/dev#7544