### PR TITLE
feat: add mimir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,39 @@ Configuration files are saved inside the state directory. The most important fil
   - templates.d: directory containing custom alert templates
 - local.yml: Grafana configuration, if enabled
 
+### Mimir alerting (my.nethesis.it)
+
+Before proceeding, make sure the cluster has already a valid subscription with my.nethesis.it.
+
+If the cluster subscription includes Mimir integration credentials, alerts can be forwarded directly to the my.nethesis.it Mimir instance through the alert-proxy service.
+The following subscription parameters enable this feature:
+- `my_url`: Base URL of the Mimir proxy (e.g., `https://qa.my.nethesis.it`)
+- `my_system_key`: HTTP Basic Auth username
+- `my_system_secret`: HTTP Basic Auth password
+
+When all three parameters are set, the alert-proxy service will automatically forward all alerts to the Mimir alertmanager API endpoint.
+The webhook URL is constructed as: `{my_url}/collect/api/services/mimir/alertmanager/api/v2/alerts`
+
+To enable Mimir integration, set the subscription configuration in Redis then trigger a subscription change event:
+Execute all commands on the leader node with root privileges:
+
+```bash
+redis-cli HSET cluster/subscription \
+  my_url 'https://qa.my.nethesis.it' \
+  my_system_key 'your-system-key' \
+  my_system_secret 'your-system-secret'
+
+runagent -m metrics1 systemctl --user restart alert-proxy
+```
+
+To disable Mimir integration, remove the subscription parameters:
+
+```bash
+redis-cli HDEL cluster/subscription my_url my_system_key my_system_secret
+
+runagent -m metrics1 systemctl --user restart alert-proxy
+```
+
 ### Customimze alert rules (experimental)
 
 **This is an experimental feature, do not use in production.**

--- a/README.md
+++ b/README.md
@@ -66,38 +66,24 @@ Configuration files are saved inside the state directory. The most important fil
   - templates.d: directory containing custom alert templates
 - local.yml: Grafana configuration, if enabled
 
-### Mimir alerting (my.nethesis.it)
+### Forwarding alerts to my.nethesis.it
 
-Before proceeding, make sure the cluster has already a valid subscription with my.nethesis.it.
+Enterprise (`nsent`) clusters with a valid my.nethesis.it subscription forward
+their alerts automatically, mirroring `send-heartbeat` / `send-inventory` in
+ns8-core. The alert-proxy POSTs alerts to the credential-translation proxy at
+`https://my.nethesis.it/proxy/alerts` using the existing subscription
+credentials (`system_id` / `auth_token`), which the proxy maps to the new my
+credentials before forwarding them to the Mimir alertmanager. No extra
+configuration is required: `write-alert-proxy-envfile` derives everything from
+`cluster/subscription`.
 
-If the cluster subscription includes Mimir integration credentials, alerts can be forwarded directly to the my.nethesis.it Mimir instance through the alert-proxy service.
-The following subscription parameters enable this feature:
-- `my_url`: Base URL of the Mimir proxy (e.g., `https://qa.my.nethesis.it`)
-- `my_system_key`: HTTP Basic Auth username
-- `my_system_secret`: HTTP Basic Auth password
+Community (`nscom`) clusters keep sending alerts to dartagnan
+(my.nethserver.com) and are unaffected.
 
-When all three parameters are set, the alert-proxy service will automatically forward all alerts to the Mimir alertmanager API endpoint.
-The webhook URL is constructed as: `{my_url}/collect/api/services/mimir/alertmanager/api/v2/alerts`
-
-To enable Mimir integration, set the subscription configuration in Redis then trigger a subscription change event:
-Execute all commands on the leader node with root privileges:
-
-```bash
-redis-cli HSET cluster/subscription \
-  my_url 'https://qa.my.nethesis.it' \
-  my_system_key 'your-system-key' \
-  my_system_secret 'your-system-secret'
-
-runagent -m metrics1 systemctl --user restart alert-proxy
-```
-
-To disable Mimir integration, remove the subscription parameters:
-
-```bash
-redis-cli HDEL cluster/subscription my_url my_system_key my_system_secret
-
-runagent -m metrics1 systemctl --user restart alert-proxy
-```
+> Migration note: the my switch-off release will repoint this from
+> `/proxy/alerts` to the native collect endpoint
+> (`/collect/api/services/mimir/alertmanager/api/v2/alerts`) with rotated
+> credentials.
 
 ### Customimze alert rules (experimental)
 

--- a/alert-proxy/README.md
+++ b/alert-proxy/README.md
@@ -1,7 +1,8 @@
 # alert-proxy
 
 `alert-proxy` is a Python-based web service designed to handle alert notifications. 
-It receives alerts from alertermanagervia HTTP POST requests, processes them, and sends them to a my.nethesis.it or my.nethserver.com.
+It receives alerts from alertermanager via HTTP POST requests, processes them, and sends them to a my.nethesis.it or my.nethserver.com.
+It also supports forwarding alerts directly to a Mimir instance for integration with my.nethesis.it.
 It listens on port `9095`.
 
 Requirements
@@ -16,6 +17,11 @@ The service relies on several environment variables for its configuration:
 - `NMON_ALERT_PROVIDER`: Alert provider (`nsent` or `nscom`).
 - `NMON_ALERT_SYSTEM_ID`: System identifier for the alerts.
 - `NMON_DARTAGNAN_URL`: URL for the Dartagnan service (used if `NMON_ALERT_PROVIDER` is `nscom`).
+- `MIMIR_URL`: (Optional) URL of the Mimir alertmanager API endpoint (e.g., `https://qa.my.nethesis.it/collect/api/services/mimir/alertmanager/api/v2/alerts`).
+- `MIMIR_AUTH_USER`: (Optional) Username for HTTP Basic authentication to Mimir.
+- `MIMIR_AUTH_PASSWORD`: (Optional) Password for HTTP Basic authentication to Mimir.
+
+When all three Mimir environment variables are set, the alert-proxy will forward all received alerts directly to the Mimir instance using HTTP Basic authentication.
 
 ## Endpoints
 

--- a/alert-proxy/README.md
+++ b/alert-proxy/README.md
@@ -17,11 +17,11 @@ The service relies on several environment variables for its configuration:
 - `NMON_ALERT_PROVIDER`: Alert provider (`nsent` or `nscom`).
 - `NMON_ALERT_SYSTEM_ID`: System identifier for the alerts.
 - `NMON_DARTAGNAN_URL`: URL for the Dartagnan service (used if `NMON_ALERT_PROVIDER` is `nscom`).
-- `MIMIR_URL`: (Optional) URL of the Mimir alertmanager API endpoint (e.g., `https://qa.my.nethesis.it/collect/api/services/mimir/alertmanager/api/v2/alerts`).
-- `MIMIR_AUTH_USER`: (Optional) Username for HTTP Basic authentication to Mimir.
-- `MIMIR_AUTH_PASSWORD`: (Optional) Password for HTTP Basic authentication to Mimir.
+- `MIMIR_URL`: (Optional) URL the alerts are forwarded to. During the my migration window `write-alert-proxy-envfile` sets this to the credential-translation proxy (`https://my.nethesis.it/proxy/alerts`); the switch-off release repoints it to the native collect endpoint (`https://my.nethesis.it/collect/api/services/mimir/alertmanager/api/v2/alerts`).
+- `MIMIR_AUTH_USER`: (Optional) Username for HTTP Basic authentication (the subscription `system_id`).
+- `MIMIR_AUTH_PASSWORD`: (Optional) Password for HTTP Basic authentication (the subscription `auth_token`).
 
-When all three Mimir environment variables are set, the alert-proxy will forward all received alerts directly to the Mimir instance using HTTP Basic authentication.
+When all three Mimir environment variables are set, the alert-proxy forwards all received alerts to that endpoint using HTTP Basic authentication.
 
 ## Endpoints
 

--- a/alert-proxy/alert-proxy
+++ b/alert-proxy/alert-proxy
@@ -10,6 +10,7 @@ import aiohttp
 import json
 import sys
 import os
+import base64
 from aiohttp import web
 
 # Alarm states
@@ -23,6 +24,9 @@ auth_token = os.environ.get("NMON_ALERT_AUTH_TOKEN")
 alert_provider = os.environ.get("NMON_ALERT_PROVIDER")
 system_id = os.environ.get("NMON_ALERT_SYSTEM_ID")
 dartagnan_url = os.environ.get("NMON_DARTAGNAN_URL")
+mimir_url = os.environ.get("MIMIR_URL")
+mimir_auth_user = os.environ.get("MIMIR_AUTH_USER")
+mimir_auth_password = os.environ.get("MIMIR_AUTH_PASSWORD")
 
 async def send_alert(url, value, alert, retry=3):
     if value == CLEAR:
@@ -66,29 +70,76 @@ async def raise_alert(value, alert):
     elif alert_provider == 'nscom':
         await send_alert(f'{dartagnan_url}/machine/alerts/store', value, alert)
 
+async def forward_to_mimir(alerts):
+    if not mimir_url or not mimir_auth_user or not mimir_auth_password:
+        return
+
+    try:
+        credentials = base64.b64encode(f"{mimir_auth_user}:{mimir_auth_password}".encode()).decode()
+        headers = {'Authorization': f'Basic {credentials}', 'Content-Type': 'application/json'}
+
+        ctimeout = aiohttp.ClientTimeout(total=60.0, connect=50, sock_connect=40, sock_read=10)
+        async with aiohttp.ClientSession(timeout=ctimeout) as cs:
+            await cs.post(mimir_url, json=alerts, headers=headers)
+        print(f"Forwarded {len(alerts)} alerts to Mimir", file=sys.stderr)
+    except Exception as ex:
+        print(f"Failed to forward alerts to Mimir: {str(ex)}", file=sys.stderr)
+
 async def handle_post_request(request):
-    # Convert alertsmanager alerts into my alert format
     try:
         data = await request.json()
         print("Received alert:", json.dumps(data), file=sys.stderr)
         alerts = data.get('alerts', [])
+
+        # Forward alerts to Mimir if configured
+        if mimir_url:
+            await forward_to_mimir(alerts)
+
+        # Convert alertsmanager alerts into my alert format
         for alert in alerts:
             status = alert.get('status')
             labels = alert.get('labels', {})
             node_id = labels.get('node', 'unknown')
-            # Remap to my alert id format
             alert_name = labels.get('alertname', 'unknown')
-            if alert_name == 'disk_full':
+
+            # Remap UpperCamelCase alert names to internal alert id format
+            if alert_name == 'DiskSpaceLow':
+                mountpoint = labels.get('mountpoint')
+                if mountpoint:
+                    dir = os.path.basename(mountpoint)
+                    alert_id = f'disk-low:{dir}:node:{node_id}'
+                else:
+                    alert_id = f'disk-low:{labels.get("device", "unknown")}:node:{node_id}'
+            elif alert_name == 'DiskSpaceCritical':
                 mountpoint = labels.get('mountpoint')
                 if mountpoint:
                     dir = os.path.basename(mountpoint)
                     alert_id = f'disk-full:{dir}:node:{node_id}'
                 else:
-                    alert_id = f'disk_:{labels.get('device')}:node:{node_id}'
-            elif alert_name == 'swap_full':
+                    alert_id = f'disk:{labels.get("device", "unknown")}:node:{node_id}'
+            elif alert_name == 'SwapFull':
                 alert_id = f'swap:node:{node_id}'
+            elif alert_name == 'SwapNotPresent':
+                alert_id = f'swap-notpresent:node:{node_id}'
+            elif alert_name == 'RaidDiskFailed':
+                alert_id = f'raid-disk-failed:{labels.get("device", "unknown")}:node:{node_id}'
+            elif alert_name == 'RaidDriveMissing':
+                alert_id = f'raid-drive-missing:{labels.get("device", "unknown")}:node:{node_id}'
+            elif alert_name == 'BackupFailed':
+                alert_id = f'backup-failed:{labels.get("name", "unknown")}:node:{node_id}'
+            elif alert_name == 'NodeOffline':
+                alert_id = f'node-offline:node:{node_id}'
+            elif alert_name == 'LokiOffline':
+                alert_id = f'loki-offline:node:{node_id}'
+            elif alert_name == 'CertExpiringSoon':
+                alert_id = f'cert-expiring-soon:{labels.get("cn", "unknown")}:node:{node_id}'
+            elif alert_name == 'CertExpiringCritical':
+                alert_id = f'cert-expiring-critical:{labels.get("cn", "unknown")}:node:{node_id}'
+            elif alert_name == 'CertExpired':
+                alert_id = f'cert-expired:{labels.get("cn", "unknown")}:node:{node_id}'
             else:
-                alert_id = f"{alert_name.replace('_', ':')}:{node_id}"
+                alert_id = f"{alert_name.lower().replace('_', '-')}:node:{node_id}"
+
             if status == 'firing':
                 value = CRITICAL
             elif status == 'resolved':

--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -15,14 +15,16 @@ with open('rules.d/nodes.yml', 'w') as f:
     f.write('''groups:
 - name: Nodes
   rules:
-  - alert: node_offline
+  - alert: NodeOffline
     expr: up{job="providers",target_type="node"} == 0
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "Cluster node {{ $labels.node }} is offline"
-      description: "The node target has disappeared. This may be caused by a network outage or a software issue, for example if its metric exporter has crashed."
+      summary_en: "Cluster node {{ $labels.node }} is offline"
+      summary_it: "Nodo cluster {{ $labels.node }} è offline"
+      description_en: "The node  {{ $labels.node }} has disappeared. This may be caused by a network outage or a software issue, for example if its metric exporter has crashed."
+      description_it: "Il nodo {{ $labels.node }} è scomparso. Potrebbe essere causato da un'interruzione di rete o da un problema software."
 ''')
 
 # Write the loki.yml file
@@ -30,15 +32,18 @@ with open('rules.d/loki.yml', 'w') as f:
     f.write('''groups:
 - name: Loki
   rules:
-  - alert: loki_offline
+  - alert: LokiOffline
     expr: up{job="loki"} == 0
     for: 0m
     labels:
       severity: warning
+      service: loki
       node: ''' + os.getenv("NODE_ID") + '''
     annotations:
-      summary: Loki instance {{ $labels.instance }} is down
-      description: "Loki is stopped or is not running properly.\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}"
+      summary_en: "Loki instance {{ $labels.instance }} is down (node {{ $labels.node }})"
+      summary_it: "Istanza Loki {{ $labels.instance }} è offline (nodo {{ $labels.node }})"
+      description_en: "Loki is stopped or is not running properly on node {{ $labels.node }}."
+      description_it: "Loki è arrestato o non funziona correttamente sul nodo {{ $labels.node }}."
 ''')
 
 # Write the memory.yml file
@@ -46,23 +51,27 @@ with open('rules.d/memory.yml', 'w') as f:
     f.write('''groups:
 - name: Memory
   rules:
-  - alert: swap_full
+  - alert: SwapFull
     expr: ((1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80)
     for: 10m
     labels:
       severity: warning
     annotations:
-      summary: Host swap is filling up (instance {{ $labels.instance }})
-      description: "Swap is filling up (>80%)\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}"
+      summary_en: "Host swap is filling up (node {{ $labels.node }})"
+      summary_it: "Lo spazio swap si sta riempiendo (nodo {{ $labels.node }})"
+      description_en: "Swap is filling up (>80%) on node {{ $labels.node }}. Current value: {{ $value }}%"
+      description_it: "Lo spazio swap si sta riempiendo (>80%) sul nodo {{ $labels.node }}. Valore attuale: {{ $value }}%"
 
-  - alert: swap_notpresent
+  - alert: SwapNotPresent
     expr: node_memory_SwapTotal_bytes == 0
     for: 0m
     labels:
       severity: critical
     annotations:
-      summary: Swap not configured (instance {{ $labels.instance }})
-      description: "Swap is not configured on this host.\\n "
+      summary_en: "Swap not configured (node {{ $labels.node }})"
+      summary_it: "Swap non configurato (nodo {{ $labels.node }})"
+      description_en: "Swap is not configured on node {{ $labels.node }}."
+      description_it: "Lo swap non è configurato sul nodo {{ $labels.node }}."
 ''')
 
 
@@ -71,32 +80,53 @@ with open('rules.d/disk.yml', 'w') as f:
     f.write('''groups:
 - name: Disk
   rules:
-  - alert: disk_full
+  - alert: DiskSpaceLow
+    expr: (node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} / node_filesystem_size_bytes < .20 and node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} / node_filesystem_size_bytes >= .10 and on (instance, device, mountpoint) node_filesystem_readonly == 0)
+    for: 5m
+    labels:
+      severity: warning
+      service: storage
+    annotations:
+      summary_en: "Disk usage on {{ $labels.mountpoint }} is above 80% (node {{ $labels.node }})"
+      summary_it: "Utilizzo disco su {{ $labels.mountpoint }} superiore all'80% (nodo {{ $labels.node }})"
+      description_en: "Disk space is filling up on {{ $labels.mountpoint }} on node {{ $labels.node }}. Free space is limited: {{ $value | humanize }}B"
+      description_it: "Lo spazio disco si sta riempiendo su {{ $labels.mountpoint }} sul nodo {{ $labels.node }}. Lo spazio libero è limitato: {{ $value | humanize }}B"
+
+  - alert: DiskSpaceCritical
     expr: (node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} / node_filesystem_size_bytes < .10 and on (instance, device, mountpoint) node_filesystem_readonly == 0)
     for: 2m
     labels:
-      severity: warning
+      severity: critical
+      service: storage
     annotations:
-      summary: Host out of disk space (instance {{ $labels.instance }})
-      description: "Disk is almost full (< 10% left)\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}"
+      summary_en: "Disk usage on {{ $labels.mountpoint }} is above 90% (node {{ $labels.node }})."
+      summary_it: "Utilizzo disco su {{ $labels.mountpoint }} superiore al 90% (nodo {{ $labels.node }})."
+      description_en: "Disk is almost full (< 10% left) on {{ $labels.mountpoint }} on node {{ $labels.node }}. Free space: {{ $value | humanize }}B. Immediate action is required to free up space or add more storage."
+      description_it: "Il disco è quasi pieno (< 10% disponibile) su {{ $labels.mountpoint }} sul nodo {{ $labels.node }}. Spazio libero: {{ $value | humanize }}B. È richiesta un'azione immediata per liberare spazio o aggiungere ulteriore storage."
 
-  - alert: md_failure
+  - alert: RaidDiskFailed
     expr: (node_md_disks{state="failed"} > 0)
     for: 2m
     labels:
       severity: critical
+      service: storage
     annotations:
-      summary: Host software RAID disk failure (instance {{ $labels.instance }})
-      description: "MD RAID array {{ $labels.device }} on node {{ $labels.node }} needs attention.\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}"
+      summary_en: "Host software RAID disk failure (node {{ $labels.node }})"
+      summary_it: "Guasto disco RAID software (nodo {{ $labels.node }})"
+      description_en: "MD RAID array {{ $labels.device }} on node {{ $labels.node }} has a failed disk. Immediate attention required."
+      description_it: "L'array RAID {{ $labels.device }} sul nodo {{ $labels.node }} ha un disco guasto. Attenzione immediata richiesta."
 
-  - alert: md_missing
+  - alert: RaidDriveMissing
     expr: (node_md_disks_required - on(instance, device, node) node_md_disks{state="active"}) > 0
     for: 2m
     labels:
       severity: critical
+      service: storage
     annotations:
-      summary: Host software RAID insufficient drives (instance {{ $labels.instance }})
-      description: "MD RAID array {{ $labels.device }} on node {{ $labels.node }} has insufficient drives remaining.\\n  VALUE = {{ $value }}\\n  LABELS = {{ $labels }}"
+      summary_en: "Host software RAID insufficient drives (node {{ $labels.node }})"
+      summary_it: "Array RAID software con unità insufficienti (nodo {{ $labels.node }})"
+      description_en: "MD RAID array {{ $labels.device }} on node {{ $labels.node }} has insufficient drives remaining."
+      description_it: "L'array RAID {{ $labels.device }} sul nodo {{ $labels.node }} ha un numero insufficiente di unità."
 ''')
 
 # Write the backup.yml file
@@ -104,14 +134,17 @@ with open('rules.d/backup.yml', 'w') as f:
     f.write('''groups:
 - name: Backup
   rules:
-  - alert: backup_failed
+  - alert: BackupFailed
     expr: node_backup_status == 0
     for: 0m
     labels:
       severity: critical
+      service: backup
     annotations:
-      summary: "Backup failed"
-      description: "The backup {{ $labels.name }} ({{ $labels.id }}) has failed."
+      summary_en: "Backup job {{ $labels.name }} (ID: {{ $labels.id }}) has failed."
+      summary_it: "Backup {{ $labels.name }} (ID: {{ $labels.id }}) non riuscito."
+      description_en: "Backup job {{ $labels.name }} (ID: {{ $labels.id }}) has failed and requires attention."
+      description_it: "Il backup {{ $labels.name }} (ID: {{ $labels.id }}) non è riuscito e richiede attenzione."
 ''')
 
 # Write the tlscert.yml file
@@ -119,36 +152,36 @@ with open('rules.d/tlscert.yml', 'w') as f:
     f.write(r'''groups:
 - name: TLS certificates
   rules:
-  - alert: certexp
+  - alert: CertExpiringSoon
     expr: 7d <= (max by (cn, sans) (traefik_tls_certs_not_after) - time()) < 28d
     for: 5m
     labels:
       severity: warning
     annotations:
-      summary: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
-      description: >
-        The {{ $labels.module_id }} certificate {{ $labels.cn }} valid for {{ $labels.sans }}
-        on Node {{ $labels.node }} expires in less than 28 days. It must be renewed, or
-        removed from the TLS certificates page.
-  - alert: certexp
+      summary_en: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
+      summary_it: "Certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
+      description_en: "The {{ $labels.module_id }} certificate {{ $labels.cn }} on node {{ $labels.node }} expires in less than 28 days. It must be renewed, or removed from the TLS certificates page."
+      description_it: "Il certificato {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} scade tra meno di 28 giorni. Deve essere rinnovato o rimosso dalla pagina dei certificati TLS."
+  
+  - alert: CertExpiringCritical
     expr: 0 < (max by (cn, sans) (traefik_tls_certs_not_after) - time()) < 7d
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
-      description: >
-        The {{ $labels.module_id }} certificate {{ $labels.cn }} valid for {{ $labels.sans }}
-        on Node {{ $labels.node }} expires in less than 7 days. It must be renewed, or
-        removed from the TLS certificates page.
-  - alert: certexp
+      summary_en: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
+      summary_it: "Certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
+      description_en: "The {{ $labels.module_id }} certificate {{ $labels.cn }} on node {{ $labels.node }} expires in less than 7 days. It must be renewed immediately, or removed from the TLS certificates page."
+      description_it: "Il certificato {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} scade tra meno di 7 giorni. Deve essere rinnovato immediatamente o rimosso dalla pagina dei certificati TLS."
+  
+  - alert: CertExpired
     expr: (time() - max by (cn, sans) (traefik_tls_certs_not_after)) > 0
     for: 5m
     labels:
       severity: critical
     annotations:
-      summary: "TLS certificate on Node {{ $labels.node }} has expired since {{ $value | humanizeDuration }}"
-      description: >
-        The {{ $labels.module_id }} expired certificate {{ $labels.cn }} (also for {{ $labels.sans }})
-        on Node {{ $labels.node }} must be immediately renewed, or removed from the TLS certificates page.
+      summary_en: "TLS certificate on Node {{ $labels.node }} has expired"
+      summary_it: "Certificato TLS sul nodo {{ $labels.node }} è scaduto"
+      description_en: "The {{ $labels.module_id }} expired certificate {{ $labels.cn }} on node {{ $labels.node }} must be immediately renewed or removed from the TLS certificates page."
+      description_it: "Il certificato scaduto {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} deve essere immediatamente rinnovato o rimosso dalla pagina dei certificati TLS."
 ''')

--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -22,7 +22,7 @@ with open('rules.d/nodes.yml', 'w') as f:
       severity: critical
     annotations:
       summary_en: "Cluster node {{ $labels.node }} is offline"
-      summary_it: "Nodo cluster {{ $labels.node }} è offline"
+      summary_it: "Il nodo cluster {{ $labels.node }} è offline"
       description_en: "The node  {{ $labels.node }} has disappeared. This may be caused by a network outage or a software issue, for example if its metric exporter has crashed."
       description_it: "Il nodo {{ $labels.node }} è scomparso. Potrebbe essere causato da un'interruzione di rete o da un problema software."
 ''')
@@ -41,7 +41,7 @@ with open('rules.d/loki.yml', 'w') as f:
       node: ''' + os.getenv("NODE_ID") + '''
     annotations:
       summary_en: "Loki instance {{ $labels.instance }} is down (node {{ $labels.node }})"
-      summary_it: "Istanza Loki {{ $labels.instance }} è offline (nodo {{ $labels.node }})"
+      summary_it: "L'istanza Loki {{ $labels.instance }} è offline (nodo {{ $labels.node }})"
       description_en: "Loki is stopped or is not running properly on node {{ $labels.node }}."
       description_it: "Loki è arrestato o non funziona correttamente sul nodo {{ $labels.node }}."
 ''')
@@ -142,9 +142,9 @@ with open('rules.d/backup.yml', 'w') as f:
       service: backup
     annotations:
       summary_en: "Backup job {{ $labels.name }} (ID: {{ $labels.id }}) has failed."
-      summary_it: "Backup {{ $labels.name }} (ID: {{ $labels.id }}) non riuscito."
+      summary_it: "Backup {{ $labels.name }} (ID: {{ $labels.id }}) fallito."
       description_en: "Backup job {{ $labels.name }} (ID: {{ $labels.id }}) has failed and requires attention."
-      description_it: "Il backup {{ $labels.name }} (ID: {{ $labels.id }}) non è riuscito e richiede attenzione."
+      description_it: "Il backup {{ $labels.name }} (ID: {{ $labels.id }}) è fallito e richiede attenzione."
 ''')
 
 # Write the tlscert.yml file
@@ -159,7 +159,7 @@ with open('rules.d/tlscert.yml', 'w') as f:
       severity: warning
     annotations:
       summary_en: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
-      summary_it: "Certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
+      summary_it: "Il certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
       description_en: "The {{ $labels.module_id }} certificate {{ $labels.cn }} on node {{ $labels.node }} expires in less than 28 days. It must be renewed, or removed from the TLS certificates page."
       description_it: "Il certificato {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} scade tra meno di 28 giorni. Deve essere rinnovato o rimosso dalla pagina dei certificati TLS."
   
@@ -170,7 +170,7 @@ with open('rules.d/tlscert.yml', 'w') as f:
       severity: critical
     annotations:
       summary_en: "TLS certificate on Node {{ $labels.node }} expires in {{ $value | humanizeDuration }}"
-      summary_it: "Certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
+      summary_it: "Il certificato TLS sul nodo {{ $labels.node }} scade tra {{ $value | humanizeDuration }}"
       description_en: "The {{ $labels.module_id }} certificate {{ $labels.cn }} on node {{ $labels.node }} expires in less than 7 days. It must be renewed immediately, or removed from the TLS certificates page."
       description_it: "Il certificato {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} scade tra meno di 7 giorni. Deve essere rinnovato immediatamente o rimosso dalla pagina dei certificati TLS."
   
@@ -181,7 +181,7 @@ with open('rules.d/tlscert.yml', 'w') as f:
       severity: critical
     annotations:
       summary_en: "TLS certificate on Node {{ $labels.node }} has expired"
-      summary_it: "Certificato TLS sul nodo {{ $labels.node }} è scaduto"
+      summary_it: "Il certificato TLS sul nodo {{ $labels.node }} è scaduto"
       description_en: "The {{ $labels.module_id }} expired certificate {{ $labels.cn }} on node {{ $labels.node }} must be immediately renewed or removed from the TLS certificates page."
       description_it: "Il certificato scaduto {{ $labels.cn }} del modulo {{ $labels.module_id }} sul nodo {{ $labels.node }} deve essere immediatamente rinnovato o rimosso dalla pagina dei certificati TLS."
 ''')

--- a/imageroot/bin/write-alert-proxy-envfile
+++ b/imageroot/bin/write-alert-proxy-envfile
@@ -15,13 +15,26 @@ osubscription = rdb.hgetall('cluster/subscription')
 node_name = rdb.get(f'node/{os.environ["NODE_ID"]}/ui_name') or f'node/{os.environ["NODE_ID"]}'
 
 if osubscription:
-    agent.write_envfile("alert-proxy.env", {
+    env_vars = {
         "NMON_NODE_NAME": node_name,
-        "NMON_ALERT_AUTH_TOKEN": osubscription["auth_token"],
-        "NMON_ALERT_PROVIDER": osubscription["provider"],
-        "NMON_ALERT_SYSTEM_ID": osubscription["system_id"],
+        "NMON_ALERT_AUTH_TOKEN": osubscription.get("auth_token", ""),
+        "NMON_ALERT_PROVIDER": osubscription.get("provider", ""),
+        "NMON_ALERT_SYSTEM_ID": osubscription.get("system_id", ""),
         "NMON_DARTAGNAN_URL": osubscription.get("dartagnan_url", ""),
-    })
+    }
+
+    # Add Mimir forwarding configuration if available
+    my_url = osubscription.get("my_url", "")
+    my_system_key = osubscription.get("my_system_key", "")
+    my_system_secret = osubscription.get("my_system_secret", "")
+
+    if my_url and my_system_key and my_system_secret:
+        mimir_url = my_url.rstrip('/') + '/collect/api/services/mimir/alertmanager/api/v2/alerts'
+        env_vars["MIMIR_URL"] = mimir_url
+        env_vars["MIMIR_AUTH_USER"] = my_system_key
+        env_vars["MIMIR_AUTH_PASSWORD"] = my_system_secret
+
+    agent.write_envfile("alert-proxy.env", env_vars)
 else:
     print(agent.SD_WARNING + "Could not retrieve subscription information from Redis", file=sys.stderr)
     agent.write_envfile("alert-proxy.env", {})

--- a/imageroot/bin/write-alert-proxy-envfile
+++ b/imageroot/bin/write-alert-proxy-envfile
@@ -23,16 +23,16 @@ if osubscription:
         "NMON_DARTAGNAN_URL": osubscription.get("dartagnan_url", ""),
     }
 
-    # Add Mimir forwarding configuration if available
-    my_url = osubscription.get("my_url", "")
-    my_system_key = osubscription.get("my_system_key", "")
-    my_system_secret = osubscription.get("my_system_secret", "")
-
-    if my_url and my_system_key and my_system_secret:
-        mimir_url = my_url.rstrip('/') + '/collect/api/services/mimir/alertmanager/api/v2/alerts'
-        env_vars["MIMIR_URL"] = mimir_url
-        env_vars["MIMIR_AUTH_USER"] = my_system_key
-        env_vars["MIMIR_AUTH_PASSWORD"] = my_system_secret
+    # Forward alerts to the new my.nethesis.it through the credential-translation
+    # proxy, mirroring send-heartbeat / send-inventory in ns8-core: enterprise
+    # (nsent) subscriptions POST to my.nethesis.it/proxy/alerts using the existing
+    # subscription credentials (system_id:auth_token), which the proxy maps to the
+    # new my credentials. Community (nscom) keeps using dartagnan. The my
+    # switch-off release will repoint this to the native collect path.
+    if osubscription.get("provider") == "nsent" and osubscription.get("system_id") and osubscription.get("auth_token"):
+        env_vars["MIMIR_URL"] = "https://my.nethesis.it/proxy/alerts"
+        env_vars["MIMIR_AUTH_USER"] = osubscription["system_id"]
+        env_vars["MIMIR_AUTH_PASSWORD"] = osubscription["auth_token"]
 
     agent.write_envfile("alert-proxy.env", env_vars)
 else:


### PR DESCRIPTION
:warning:  The PR has been tested and should work in common scenarios.
Waiting the release of new my.nethesis.it before releasing

---

TODO:
- test a new logic copied from NethSecurity where Prometheus directly send alerts to Mimir

Changes:
- send data to mimir instance inside new my.nethesis.it
- rename alerts to meet [new standard](https://github.com/NethServer/my/blob/main/services/mimir/README.md#alert-catalog)
- add node label to all alerts 

Example of my.nethesis.it UI:
<img width="1529" height="280" alt="image" src="https://github.com/user-attachments/assets/21e5020a-25af-456d-8d7e-4a922ee59d4c" />


Update metrics instance:
```
api-cli run update-module --data '{"module_url":"ghcr.io/nethserver/metrics:mimir","instances":["metrics1"], "force": true}'
```

To test it, enable the Mimir integration: https://github.com/NethServer/ns8-metrics/blob/mimir/README.md#mimir-alerting-mynethesisit