### PR TITLE
Add NethVoice failed unit alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available alerts:
 - SWAP is getting full
 - One ore more backups have failed
 - Paritions are getting full
+- NethVoice systemd services are in failed state
 
 By default, the system will send alerts only to Nethesis portals.
 Mail notifications can be enabled by setting the `mail_to` parameter, see the [Configure](#configure) section.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Available alerts:
 - SWAP is getting full
 - One ore more backups have failed
 - Paritions are getting full
-- NethVoice systemd services are in failed state
+- NethVoice and NethVoice Proxy systemd services are in failed state
 
 By default, the system will send alerts only to Nethesis portals.
 Mail notifications can be enabled by setting the `mail_to` parameter, see the [Configure](#configure) section.

--- a/alert-proxy/alert-proxy
+++ b/alert-proxy/alert-proxy
@@ -137,6 +137,8 @@ async def handle_post_request(request):
                 alert_id = f'cert-expiring-critical:{labels.get("cn", "unknown")}:node:{node_id}'
             elif alert_name == 'CertExpired':
                 alert_id = f'cert-expired:{labels.get("cn", "unknown")}:node:{node_id}'
+            elif alert_name == 'SystemdUnitFailed':
+                alert_id = f'systemd-unit-failed:{labels.get("module_id", "unknown")}:{labels.get("name", "unknown")}:node:{node_id}'
             else:
                 alert_id = f"{alert_name.lower().replace('_', '-')}:node:{node_id}"
 

--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -152,7 +152,7 @@ with open('rules.d/systemd.yml', 'w') as f:
 - name: Systemd
   rules:
   - alert: SystemdUnitFailed
-    expr: systemd_unit_state{target_type="systemd", module_id=~"nethvoice[0-9]*", type="service", state="failed"} == 1
+    expr: systemd_unit_state{target_type="systemd", module_id=~"nethvoice(-proxy)?[0-9]*", type="service", state="failed"} == 1
     for: 2m
     labels:
       severity: critical

--- a/imageroot/actions/create-module/30alerts
+++ b/imageroot/actions/create-module/30alerts
@@ -146,6 +146,24 @@ with open('rules.d/backup.yml', 'w') as f:
       description_it: "Il backup {{ $labels.name }} (ID: {{ $labels.id }}) è fallito e richiede attenzione."
 ''')
 
+# Write the systemd.yml file
+with open('rules.d/systemd.yml', 'w') as f:
+    f.write('''groups:
+- name: Systemd
+  rules:
+  - alert: SystemdUnitFailed
+    expr: systemd_unit_state{target_type="systemd", module_id=~"nethvoice[0-9]*", type="service", state="failed"} == 1
+    for: 2m
+    labels:
+      severity: critical
+      service: nethvoice
+    annotations:
+      summary_en: "Systemd unit {{ $labels.name }} has failed ({{ $labels.module_id }}, node {{ $labels.node }})"
+      summary_it: "Unità systemd {{ $labels.name }} fallita ({{ $labels.module_id }}, nodo {{ $labels.node }})"
+      description_en: "Systemd unit {{ $labels.name }} for {{ $labels.module_id }} on node {{ $labels.node }} is in failed state."
+      description_it: "L'unità systemd {{ $labels.name }} per {{ $labels.module_id }} sul nodo {{ $labels.node }} è in stato failed."
+''')
+
 # Write the tlscert.yml file
 with open('rules.d/tlscert.yml', 'w') as f:
     f.write(r'''groups:

--- a/tests/10__check_services.robot
+++ b/tests/10__check_services.robot
@@ -22,6 +22,8 @@ Check if alert-proxy is running
 Check if failed systemd unit alert is loaded
     Wait Until Keyword Succeeds    10    1s
     ...    Prometheus rule exists    SystemdUnitFailed
+    Wait Until Keyword Succeeds    10    1s
+    ...    Prometheus output contains    nethvoice(-proxy)?[0-9]*
 
 Check if module can be configured
     ${rc} =    Execute Command    api-cli run module/${MID}/configure-module --data '{"prometheus_path": "prometheus", "grafana_path": "grafana"}'
@@ -49,6 +51,12 @@ HTTP GET has status 200
 Prometheus rule exists
     [Arguments]    ${rule_name}
     ${rc} =    Execute Command    curl -fsS http://127.0.0.1:9091/api/v1/rules | grep -q '"name":"${rule_name}"'
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+Prometheus output contains
+    [Arguments]    ${substring}
+    ${rc} =    Execute Command    curl -fsS http://127.0.0.1:9091/api/v1/rules | grep -Fq '${substring}'
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 

--- a/tests/10__check_services.robot
+++ b/tests/10__check_services.robot
@@ -19,6 +19,10 @@ Check if alert-proxy is running
     Wait Until Keyword Succeeds    10    1s
     ...    HTTP GET has status 200    http://127.0.0.1:9095/
 
+Check if failed systemd unit alert is loaded
+    Wait Until Keyword Succeeds    10    1s
+    ...    Prometheus rule exists    SystemdUnitFailed
+
 Check if module can be configured
     ${rc} =    Execute Command    api-cli run module/${MID}/configure-module --data '{"prometheus_path": "prometheus", "grafana_path": "grafana"}'
     ...    return_rc=True  return_stdout=False
@@ -40,6 +44,12 @@ Check if Prometheus is accessible from Traefik with basic auth
 HTTP GET has status 200
     [Arguments]    ${url}
     ${rc} =     Execute Command    curl -f '${url}'    return_rc=True    return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+Prometheus rule exists
+    [Arguments]    ${rule_name}
+    ${rc} =    Execute Command    curl -fsS http://127.0.0.1:9091/api/v1/rules | grep -q '"name":"${rule_name}"'
+    ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
 HTTP-Basic authentication accepted


### PR DESCRIPTION
## Summary

Add a built-in Prometheus alert for failed systemd service units exposed by
module exporters. The current selector is intentionally scoped to NethVoice and
NethVoice Proxy modules, matching `nethvoice[0-9]*` and
`nethvoice-proxy[0-9]*` module IDs.

This solves the immediate NethVoice use case, but the approach can be
generalized later to cover systemd service failures for all modules that expose
the same metric labels.

The PR also wires the alert to alert-proxy with a stable legacy alert ID,
checks that Prometheus loads the rule in Robot tests, and documents the new
available alert.

## Related issue

https://github.com/NethServer/dev/issues/8093

## How to test

Automated checks already passed on this branch:

- `Publish images`
- `Test module` install scenario
- `Test module` update scenario

Manual/local validation performed before opening the PR:

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile alert-proxy/alert-proxy
robot --dryrun --outputdir /tmp/ns8-metrics-robot-dryrun tests/10__check_services.robot
git diff --check
```

On an NS8 cluster with NethVoice or NethVoice Proxy exposing
`systemd_unit_state`, put one of their service units in `failed` state and
verify that Prometheus fires `SystemdUnitFailed` after 2 minutes.

## Dependencies

Depends on the NethVoice exporter metric introduced by:

- https://github.com/nethesis/ns8-nethvoice/pull/907
