### PR TITLE
Enforce module identity across metric alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,26 +200,83 @@ When a module wants to add a new target, it must use the `metrics-target-changed
 
 #### metrics-target-changed event
 
-The `provision-prometheus` script will search for the following key: `module/<module_id>/metrics_targets`.
-The key is an hash containing the following fields:
-- key `<name>`, a name for the target
-- value `<yaml_config>`, the YAML configuration for the target
+The `provision-prometheus` script searches for targets in:
 
-Example of a target configuration for the `postgresql1` module in JSON format:
-```
-cat target.yaml | redis-cli -x hset module/postgresql1/metrics_targets postgres
+```text
+module/<publisher_id>/metrics_targets
 ```
 
-Content of the `target.yaml` file:
+The Redis hash contains:
+
+- field `<target_type>`, a stable name identifying the target type;
+- value `<yaml_config>`, a Prometheus `file_sd_config` YAML list.
+
+The publisher ID from the Redis key is authoritative. For every target,
+provisioning:
+
+- creates the `labels` mapping when it is absent;
+- sets `module_id` to `<publisher_id>`;
+- sets `target_type` to the Redis field name;
+- preserves every other label.
+
+Provider-supplied `module_id` and `target_type` values cannot override this
+identity. Conflicting values are replaced and reported with their Redis key,
+field, and item position.
+
+Each Redis field is validated independently. A malformed field is skipped
+without preventing valid fields from the same or other publishers from being
+materialized.
+
+For example, publish a PostgreSQL target with:
+
+```sh
+redis-cli -x hset \
+  module/postgresql1/metrics_targets \
+  postgres < target.yml
+```
+
+Content of `target.yml`:
+
 ```yaml
 - targets:
   - 10.5.4.1:9187
   labels:
-    module_id: postresql1
+    node: "1"
 ```
 
-The configuration will be saved on a YAML file inside the `prometheus.d` directory, named like `provision_<module_id>_<name>.json`.
+Provisioning adds the authoritative labels:
 
+```yaml
+- targets:
+  - 10.5.4.1:9187
+  labels:
+    node: "1"
+    module_id: postgresql1
+    target_type: postgres
+```
+
+The generated configuration is saved as:
+
+```text
+prometheus.d/provision_<publisher_id>_<target_type>.yml
+```
+
+After adding, updating, or removing a target, the publisher must emit the
+`metrics-target-changed` event.
+
+#### Provider alert identity
+
+Alerts carrying `module_id` are grouped by Alertmanager using `alertname`,
+`node`, and `module_id`. This keeps same-name alerts from different module
+instances in separate notification groups.
+
+Critical alerts inhibit warning alerts only when both `alertname` and
+`module_id` match. Alerts without `module_id`, such as alerts generated from
+cluster-node targets, retain their previous grouping and inhibition behavior.
+
+Downstream identifiers are also scoped by a non-empty `module_id`, preventing
+a resolved alert from one module instance from clearing a same-name alert that
+is still firing for another instance.
 
 ### Provisioning Grafana
 

--- a/alert-proxy/README.md
+++ b/alert-proxy/README.md
@@ -34,6 +34,42 @@ When all three Mimir environment variables are set, the alert-proxy forwards all
 
 ## Alert format
 
+### Alert identifiers
+
+For portal forwarding, `alert-proxy` converts Prometheus alert labels into
+legacy Nethesis alert identifiers.
+
+When an alert contains a non-empty string `module_id`, the module identity is
+inserted immediately before the existing `node` suffix. This applies to both
+explicitly mapped alert names and the generic fallback.
+
+For example:
+
+```text
+loki-offline:loki1:node:4
+application-down:postgresql1:node:2
+```
+
+Alerts without `module_id` retain their exact legacy identifiers:
+
+```text
+loki-offline:node:4
+application-down:node:2
+```
+
+This preserves compatibility for module-less alerts while preventing
+same-name alerts from different module instances from sharing an identifier.
+
+During an upgrade, an alert already active under an unscoped identifier may
+remain visible downstream until handled by the downstream retention policy.
+Rolling back to an older `alert-proxy` restores unscoped identifiers and their
+cross-module collision risk.
+
+Mimir forwarding is unaffected: the complete original alert payload is
+forwarded without modification.
+
+### Examples
+
 Raise an alert for /boot disk full:
 ```
 echo '{"receiver": "default-receiver", "status": "firing", "alerts": [{"status": "firing", "labels": {"alertname": "disk_full", "device": "/dev/vda2", "fstype": "xfs", "instance": "10.5.4.1:9100", "job": "providers", "mountpoint": "/boot", "node": "1", "severity": "warning"}, "annotations": {"description": "Disk is almost full (< 10% left)\n  VALUE = 0.009680310021459396\n  LABELS = map[device:/dev/vda2 fstype:xfs instance:10.5.4.1:9100 job:providers mountpoint:/boot node:1]", "summary": "Host out of disk space (instance 10.5.4.1:9100)"}, "startsAt": "2025-02-25T10:55:26.18Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "/prometheus/graph?g0.expr=%28node_filesystem_avail_bytes%7Bfstype%21~%22%5E%28fuse.%2A%7Ctmpfs%7Ccifs%7Cnfs%29%22%7D+%2F+node_filesystem_size_bytes+%3C+0.1+and+on+%28instance%2C+device%2C+mountpoint%29+node_filesystem_readonly+%3D%3D+0%29&g0.tab=1", "fingerprint": "355cfca350bfe294"}], "groupLabels": {"alertname": "disk_full", "node": "1"}, "commonLabels": {"alertname": "disk_full", "device": "/dev/vda2", "fstype": "xfs", "instance": "10.5.4.1:9100", "job": "providers", "mountpoint": "/boot", "node": "1", "severity": "warning"}, "commonAnnotations": {"description": "Disk is almost full (< 10% left)\n  VALUE = 0.009680310021459396\n  LABELS = map[device:/dev/vda2 fstype:xfs instance:10.5.4.1:9100 job:providers mountpoint:/boot node:1]", "summary": "Host out of disk space (instance 10.5.4.1:9100)"}, "externalURL": "http://rl1.leader.cluster0.gs.nethserver.net:9093", "version": "4", "groupKey": "{}/{service=~\".*\"}:{alertname=\"disk_full\", node=\"1\"}", "truncatedAlerts": 0}' | curl -H "Content-Type: application/json"  --data-binary @- http://localhost:9095

--- a/alert-proxy/alert-proxy
+++ b/alert-proxy/alert-proxy
@@ -140,6 +140,14 @@ async def handle_post_request(request):
             else:
                 alert_id = f"{alert_name.lower().replace('_', '-')}:node:{node_id}"
 
+            module_id = labels.get('module_id')
+            if isinstance(module_id, str) and module_id:
+                node_suffix = f':node:{node_id}'
+                alert_id = (
+                    f'{alert_id.removesuffix(node_suffix)}:'
+                    f'{module_id}{node_suffix}'
+                )
+
             if status == 'firing':
                 value = CRITICAL
             elif status == 'resolved':

--- a/imageroot/bin/provision-prometheus
+++ b/imageroot/bin/provision-prometheus
@@ -5,17 +5,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import os
-import yaml
-import agent
 import json
+import os
 import sys
+from collections.abc import Mapping
+
+import agent
+import yaml
 
 ALERT_MANAGER_DEFAULT_CONFIG = {
     'global': {},
     'route': {
         'receiver': 'default-receiver',
-        'group_by': ['alertname', 'node'],
+        # Keep same-name alerts from different providers in separate groups.
+        'group_by': ['alertname', 'node', 'module_id'],
         'group_wait': '30s',
         'group_interval': '5m',
         'repeat_interval': '3h',
@@ -31,7 +34,8 @@ ALERT_MANAGER_DEFAULT_CONFIG = {
         {
         'source_matchers': ['severity="critical"'],
         'target_matchers': ['severity="warning"'],
-        'equal': ['alertname']
+        # A critical alert must inhibit warnings only for the same provider.
+        'equal': ['alertname', 'module_id']
         }
     ],
     'receivers': [
@@ -78,23 +82,77 @@ def validate_and_generate_provider_configs(redis_client):
             file.write(f"    target_type: node\n")
             file.write(f"    node: {node_id}\n")
 
-    def _decorate_with_target_type_label(data, target_type):
-        for oitem in data:
-            oitem['labels']['target_type'] = target_type
-
     for module in redis_client.scan_iter("module/*/metrics_targets"):
         module_id = module.split('/')[1]
         targets = redis_client.hgetall(module)
         for db_key, db_val in targets.items():
+            # Isolate malformed fields so valid targets from the same provider
+            # can still be materialized.
             try:
                 data = yaml.safe_load(db_val)
-                _decorate_with_target_type_label(data, db_key)
-            except Exception as ex:
+                data = normalize_provider_targets(
+                    data,
+                    redis_key=module,
+                    target_type=db_key,
+                    module_id=module_id,
+                )
+            except (TypeError, ValueError, yaml.YAMLError) as ex:
                 print(f"Skipped target {db_key} for module {module_id}: {ex}", file=sys.stderr)
                 continue
             filename = f"prometheus.d/provision_{module_id}_{db_key}.yml"
-            with open(filename, 'w') as fp:
+            with open(filename, 'w', encoding='utf-8') as fp:
                  yaml.safe_dump(data, fp, sort_keys=False)
+
+def normalize_provider_targets(
+    data, redis_key, target_type, module_id, warning_stream=None
+):
+    """Validate targets and enforce their Redis-derived identity labels."""
+
+    # A Redis field represents one Prometheus file_sd document. Reject the
+    # complete field if its top-level shape cannot contain target entries.
+    if not isinstance(data, list):
+        raise ValueError("target document must be a list of mappings")
+
+    # Allow callers and tests to capture warnings without redirecting stderr.
+    if warning_stream is None:
+        warning_stream = sys.stderr
+
+    normalized_targets = []
+    # The Redis key and field identify the provider and target type. Payload
+    # labels cannot override that authoritative ownership.
+    authoritative_labels = {
+        'module_id': module_id,
+        'target_type': target_type,
+    }
+    for index, target in enumerate(data):
+        # Every file_sd target entry must be a mapping. Rejecting the field here
+        # avoids writing a partially valid provider configuration.
+        if not isinstance(target, Mapping):
+            raise ValueError(f"target item {index} must be a mapping")
+
+        # Copy provider-owned mappings before normalization so validation does
+        # not mutate the object returned by the YAML decoder.
+        normalized_target = dict(target)
+        labels = normalized_target.get('labels', {})
+        if not isinstance(labels, Mapping):
+            raise ValueError(f"target item {index} labels must be a mapping")
+
+        labels = dict(labels)
+        for label_name, effective_value in authoritative_labels.items():
+            # Report spoofed or stale identity before replacing it with the
+            # value derived from the Redis key and field.
+            if label_name in labels and labels[label_name] != effective_value:
+                print(
+                    f"Target label conflict at Redis key {redis_key}, "
+                    f"field {target_type}, item {index}: {label_name}="
+                    f"{labels[label_name]!r} overwritten with {effective_value!r}",
+                    file=warning_stream,
+                )
+            labels[label_name] = effective_value
+        normalized_target['labels'] = labels
+        normalized_targets.append(normalized_target)
+
+    return normalized_targets
 
 def clean_up_old_provider_configs(redis_client):
     nodes = []
@@ -203,20 +261,25 @@ def generate_custom_alertmanager_templates(redis_client):
             if template:
                 f.write(template)
 
-# connect to client and fetch providers for prometheus
-redis_client = agent.redis_connect(use_replica=True)
+def main():
+    # connect to client and fetch providers for prometheus
+    redis_client = agent.redis_connect(use_replica=True)
 
-# This script can run before create-module, as event
-# handler. Ensure required dir exists:
-os.makedirs("prometheus.d", exist_ok=True)
+    # This script can run before create-module, as event
+    # handler. Ensure required dir exists:
+    os.makedirs("prometheus.d", exist_ok=True)
 
-# Generate providers configuration
-clean_up_old_provisioned_targets(redis_client)
-generate_prometheus_config(redis_client)
-validate_and_generate_provider_configs(redis_client)
-clean_up_old_provider_configs(redis_client)
+    # Generate providers configuration
+    clean_up_old_provisioned_targets(redis_client)
+    generate_prometheus_config(redis_client)
+    validate_and_generate_provider_configs(redis_client)
+    clean_up_old_provider_configs(redis_client)
 
-# Generate alertmanager configuration
-generate_alertmanagr_config(redis_client)
-generate_custom_alertmanager_rules(redis_client)
-generate_custom_alertmanager_templates(redis_client)
+    # Generate alertmanager configuration
+    generate_alertmanagr_config(redis_client)
+    generate_custom_alertmanager_rules(redis_client)
+    generate_custom_alertmanager_templates(redis_client)
+
+# Keep helper functions importable without connecting to Redis during tests.
+if __name__ == '__main__':
+    main()

--- a/tests/00__unit_tests.robot
+++ b/tests/00__unit_tests.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation    Run the local Python unit-test suite
+Library    Process
+
+*** Test Cases ***
+Python unit tests pass
+    ${result} =    Run Process
+    ...    %{venvroot}/bin/python3
+    ...    -m
+    ...    unittest
+    ...    discover
+    ...    -s
+    ...    tests
+    ...    -p
+    ...    test_*.py
+    ...    -v
+    ...    cwd=${CURDIR}/..
+    ...    stderr=STDOUT
+    Log    ${result.stdout}    console=${True}
+    Should Be Equal As Integers    ${result.rc}    0

--- a/tests/pythonreq.txt
+++ b/tests/pythonreq.txt
@@ -1,2 +1,3 @@
 robotframework
 robotframework-sshlibrary
+PyYAML

--- a/tests/test_alert_proxy.py
+++ b/tests/test_alert_proxy.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+class FakeResponse:
+    def __init__(self, text, status):
+        self.text = text
+        self.status = status
+
+
+def load_alert_proxy():
+    aiohttp_module = types.ModuleType('aiohttp')
+    web_module = types.ModuleType('aiohttp.web')
+    web_module.Response = FakeResponse
+    aiohttp_module.web = web_module
+
+    script_path = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / 'alert-proxy'
+        / 'alert-proxy'
+    )
+    loader = importlib.machinery.SourceFileLoader(
+        'alert_proxy_under_test', str(script_path)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, {
+        'aiohttp': aiohttp_module,
+        'aiohttp.web': web_module,
+    }):
+        loader.exec_module(module)
+    return module
+
+
+alert_proxy = load_alert_proxy()
+
+
+class FakeRequest:
+    def __init__(self, labels):
+        self.labels = labels
+
+    async def json(self):
+        return {'alerts': [{'status': 'firing', 'labels': self.labels}]}
+
+
+class AlertIdentifierTests(unittest.IsolatedAsyncioTestCase):
+    async def dispatch(self, labels):
+        raise_alert = AsyncMock()
+        with (
+            patch.object(alert_proxy, 'mimir_url', ''),
+            patch.object(alert_proxy, 'raise_alert', raise_alert),
+        ):
+            response = await alert_proxy.handle_post_request(
+                FakeRequest(labels)
+            )
+        self.assertEqual(response.status, 200)
+        return raise_alert.await_args.args[1]
+
+    async def test_module_identity_scopes_mapped_and_generic_alerts(self):
+        cases = (
+            (
+                {'alertname': 'LokiOffline', 'module_id': 'loki1', 'node': '4'},
+                'loki-offline:loki1:node:4',
+            ),
+            (
+                {'alertname': 'LokiOffline', 'module_id': 'loki2', 'node': '4'},
+                'loki-offline:loki2:node:4',
+            ),
+            (
+                {
+                    'alertname': 'Application_Down',
+                    'module_id': 'postgresql1',
+                    'node': '2',
+                },
+                'application-down:postgresql1:node:2',
+            ),
+        )
+
+        for labels, expected in cases:
+            with self.subTest(labels=labels):
+                self.assertEqual(await self.dispatch(labels), expected)
+
+    async def test_moduleless_and_empty_module_ids_keep_legacy_ids(self):
+        cases = (
+            (
+                {'alertname': 'LokiOffline', 'node': '4'},
+                'loki-offline:node:4',
+            ),
+            (
+                {
+                    'alertname': 'Application_Down',
+                    'module_id': '',
+                    'node': '2',
+                },
+                'application-down:node:2',
+            ),
+        )
+
+        for labels, expected in cases:
+            with self.subTest(labels=labels):
+                self.assertEqual(await self.dispatch(labels), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_provision_prometheus.py
+++ b/tests/test_provision_prometheus.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import fnmatch
+import importlib.machinery
+import importlib.util
+import io
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import contextmanager, redirect_stderr
+from unittest.mock import patch
+
+import yaml
+
+
+@contextmanager
+def working_directory(path):
+    previous_directory = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous_directory)
+
+
+def load_provision_prometheus():
+    agent_module = types.ModuleType('agent')
+    agent_module.get_hostname = lambda: 'node.example.org'
+    agent_module.get_smarthost_settings = lambda redis_client: {'enabled': False}
+    agent_module.redis_connect = lambda use_replica: None
+    sys.modules['agent'] = agent_module
+
+    script_path = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / 'imageroot'
+        / 'bin'
+        / 'provision-prometheus'
+    )
+    loader = importlib.machinery.SourceFileLoader(
+        'provision_prometheus', str(script_path)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+provision_prometheus = load_provision_prometheus()
+
+
+class FakeRedis:
+    def __init__(self, hashes=None, sets=None):
+        self.hashes = hashes or {}
+        self.sets = sets or {}
+
+    def exists(self, key):
+        return key in self.hashes
+
+    def hgetall(self, key):
+        return self.hashes.get(key, {})
+
+    def hvals(self, key):
+        return list(self.hgetall(key).values())
+
+    def scan_iter(self, pattern):
+        keys = sorted(set(self.hashes) | set(self.sets))
+        return iter(key for key in keys if fnmatch.fnmatch(key, pattern))
+
+    def sismember(self, key, value):
+        return value in self.sets.get(key, set())
+
+
+class ProviderTargetTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_directory.cleanup)
+        self.work_directory = pathlib.Path(self.temp_directory.name)
+        (self.work_directory / 'prometheus.d').mkdir()
+
+    def generate_targets(self, redis_client):
+        with working_directory(self.work_directory):
+            provision_prometheus.validate_and_generate_provider_configs(redis_client)
+
+    def read_yaml(self, relative_path):
+        with open(self.work_directory / relative_path, encoding='utf-8') as stream:
+            return yaml.safe_load(stream)
+
+    def test_missing_labels_are_created(self):
+        redis_client = FakeRedis(hashes={
+            'module/postgresql1/metrics_targets': {
+                'postgres': '- targets: ["127.0.0.1:9187"]\n',
+            },
+        })
+
+        self.generate_targets(redis_client)
+
+        targets = self.read_yaml('prometheus.d/provision_postgresql1_postgres.yml')
+        self.assertEqual(targets[0]['labels'], {
+            'module_id': 'postgresql1',
+            'target_type': 'postgres',
+        })
+
+    def test_matching_identity_and_custom_labels_are_preserved(self):
+        redis_client = FakeRedis(hashes={
+            'module/postgresql1/metrics_targets': {
+                'postgres': '''
+- targets: ["127.0.0.1:9187"]
+  labels:
+    module_id: postgresql1
+    target_type: postgres
+    node: "1"
+    environment: production
+''',
+            },
+        })
+        warnings = io.StringIO()
+
+        with redirect_stderr(warnings):
+            self.generate_targets(redis_client)
+
+        targets = self.read_yaml('prometheus.d/provision_postgresql1_postgres.yml')
+        self.assertEqual(targets[0]['labels'], {
+            'module_id': 'postgresql1',
+            'target_type': 'postgres',
+            'node': '1',
+            'environment': 'production',
+        })
+        self.assertEqual(warnings.getvalue(), '')
+
+    def test_conflicting_identity_is_overwritten_and_warned(self):
+        redis_key = 'module/postgresql1/metrics_targets'
+        redis_client = FakeRedis(hashes={
+            redis_key: {
+                'postgres': '''
+- targets: ["127.0.0.1:9187"]
+  labels:
+    module_id: mariadb1
+    target_type: database
+''',
+            },
+        })
+        warnings = io.StringIO()
+
+        with redirect_stderr(warnings):
+            self.generate_targets(redis_client)
+
+        targets = self.read_yaml('prometheus.d/provision_postgresql1_postgres.yml')
+        self.assertEqual(targets[0]['labels']['module_id'], 'postgresql1')
+        self.assertEqual(targets[0]['labels']['target_type'], 'postgres')
+        warning_text = warnings.getvalue()
+        self.assertIn(redis_key, warning_text)
+        self.assertIn('field postgres, item 0', warning_text)
+        self.assertIn("module_id='mariadb1' overwritten with 'postgresql1'", warning_text)
+        self.assertIn("target_type='database' overwritten with 'postgres'", warning_text)
+
+    def test_malformed_field_is_skipped_without_affecting_valid_field(self):
+        malformed_documents = {
+            'invalid-yaml': '- targets: [\n',
+            'not-a-list': 'targets: ["127.0.0.1:9000"]\n',
+            'non-mapping-item': '- "127.0.0.1:9000"\n',
+            'non-mapping-labels': '''
+- targets: ["127.0.0.1:9000"]
+  labels: invalid
+''',
+        }
+
+        for malformed_name, malformed_document in malformed_documents.items():
+            with self.subTest(malformed_name=malformed_name):
+                redis_client = FakeRedis(hashes={
+                    'module/example1/metrics_targets': {
+                        malformed_name: malformed_document,
+                        'valid': '- targets: ["127.0.0.1:9001"]\n',
+                    },
+                })
+                warnings = io.StringIO()
+
+                with redirect_stderr(warnings):
+                    self.generate_targets(redis_client)
+
+                self.assertFalse(
+                    (self.work_directory / 'prometheus.d'
+                     / f'provision_example1_{malformed_name}.yml').exists()
+                )
+                self.assertTrue(
+                    (self.work_directory / 'prometheus.d'
+                     / 'provision_example1_valid.yml').exists()
+                )
+                self.assertIn(
+                    f'Skipped target {malformed_name} for module example1',
+                    warnings.getvalue(),
+                )
+
+    def test_builtin_node_target_has_no_module_id(self):
+        redis_client = FakeRedis(hashes={
+            'node/1/vpn': {'ip_address': '10.0.0.1'},
+        })
+
+        self.generate_targets(redis_client)
+
+        targets = self.read_yaml('prometheus.d/node_1.yml')
+        self.assertEqual(targets[0]['labels'], {
+            'target_type': 'node',
+            'node': 1,
+        })
+        self.assertNotIn('module_id', targets[0]['labels'])
+
+
+class AlertmanagerConfigurationTests(unittest.TestCase):
+    def test_grouping_and_inhibition_include_module_identity(self):
+        redis_client = FakeRedis()
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            with working_directory(temp_directory):
+                with patch.dict(os.environ, {'MODULE_ID': 'metrics1'}):
+                    provision_prometheus.generate_alertmanagr_config(redis_client)
+                with open('alertmanager.yml', encoding='utf-8') as stream:
+                    alertmanager_config = yaml.safe_load(stream)
+
+        self.assertEqual(
+            alertmanager_config['route']['group_by'],
+            ['alertname', 'node', 'module_id'],
+        )
+        self.assertEqual(
+            alertmanager_config['inhibit_rules'][0]['equal'],
+            ['alertname', 'module_id'],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This is the first implementation phase for provider-published Prometheus
alert rules.

Derive `module_id` and `target_type` from each provider's Redis key and
field, preventing provider-supplied labels from overriding authoritative
target identity.

Malformed target fields are isolated so they do not prevent valid sibling
fields from being materialized. Conflicting identity labels are replaced
and reported with their Redis provenance.

Alertmanager grouping and inhibition include `module_id`, keeping
same-name alerts from different module instances independent.

Downstream alert identifiers also include a non-empty `module_id`. This
prevents a resolved alert from one module instance from clearing a
same-name alert that is still firing for another instance.

Existing built-in node targets remain unchanged.

## Compatibility

Alerts without `module_id` retain their exact legacy identifiers and
behavior.

Alerts with a non-empty `module_id` intentionally receive a scoped
identifier. For example:

```text
Before: loki-offline:node:4
After:  loki-offline:loki1:node:4
```

This identifier change is required to prevent collisions between module
instances. During an upgrade, an alert already firing under its previous
unscoped identifier may remain visible downstream until handled by the
downstream retention policy.

Rolling back to an older `alert-proxy` restores the previous unscoped
identifiers and therefore also restores the cross-module collision risk.

Mimir forwarding is unaffected because the complete original alert payload
continues to be forwarded without modification.

## Related issue

NethServer/dev#8100

## How to test

```sh
env PYTHONDONTWRITEBYTECODE=1 \
  python3 -m unittest discover -s tests -p 'test_*.py' -v

env venvroot=/usr PYTHONDONTWRITEBYTECODE=1 \
  python3 -m robot --console verbose \
  --output NONE --report NONE --log NONE \
  tests/00__unit_tests.robot
```

Both commands pass: eight Python tests and one Robot test.

The tests cover:

- authoritative provider target identity;
- malformed provider-field isolation;
- Alertmanager grouping and inhibition;
- distinct mapped and generic IDs for module-scoped alerts;
- unchanged legacy IDs for module-less alerts.

## Dependencies

None.