### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/alert-proxy.service
+++ b/imageroot/systemd/user/alert-proxy.service
@@ -8,9 +8,9 @@ After=prometheus.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/alert-proxy.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/alert-proxy.env
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/alert-proxy.pid %t/alert-proxy.ctr-id
 ExecStart=/usr/bin/podman run \
@@ -20,8 +20,8 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --network=host \
-    --env-file=%S/state/environment \
-    --env-file=%S/state/alert-proxy.env \
+    --env-file=%E/state/environment \
+    --env-file=%E/state/alert-proxy.env \
     ${ALERT_PROXY_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/alert-proxy.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/alert-proxy.ctr-id

--- a/imageroot/systemd/user/alertmanager.service
+++ b/imageroot/systemd/user/alertmanager.service
@@ -8,8 +8,8 @@ After=prometheus.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/alertmanager.pid %t/alertmanager.ctr-id
 ExecStart=/usr/bin/podman run \
@@ -19,8 +19,8 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --network=host \
-    --volume=%S/state/alertmanager.yml:/alertmanager.yml:z \
-    --volume=%S/state/templates.d/:/etc/alertmanager/templates:z \
+    --volume=%E/state/alertmanager.yml:/alertmanager.yml:z \
+    --volume=%E/state/templates.d/:/etc/alertmanager/templates:z \
     --volume=alertmanager-data:/alertmanager:z \
     ${ALERTMANAGER_IMAGE} --config.file=/alertmanager.yml --web.listen-address=127.0.0.1:9093 --cluster.listen-address=127.0.0.1:9094
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/alertmanager.ctr-id -t 10

--- a/imageroot/systemd/user/grafana.service
+++ b/imageroot/systemd/user/grafana.service
@@ -7,8 +7,8 @@ Description=Grafana server
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/grafana.pid %t/grafana.ctr-id
 ExecStartPre=runagent provision-grafana
@@ -20,10 +20,10 @@ ExecStart=/usr/bin/podman run \
     --replace --name=%N \
     --network=host \
     --volume=grafana-data:/var/lib/grafana:z \
-    --volume=%S/state/datasources/:/etc/grafana/provisioning/datasources:z \
-    --volume=%S/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
-    --volume=%S/state/dashboards/:/etc/grafana/dashboards:z \
-    --volume=%S/etc/grafana.ini:/etc/grafana/grafana.ini:z \
+    --volume=%E/state/datasources/:/etc/grafana/provisioning/datasources:z \
+    --volume=%E/etc/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:z \
+    --volume=%E/state/dashboards/:/etc/grafana/dashboards:z \
+    --volume=%E/etc/grafana.ini:/etc/grafana/grafana.ini:z \
     -e GF_SERVER_SERVE_FROM_SUB_PATH=true \
     -e GF_SERVER_ROOT_URL=/${GRAFANA_PATH} \
     -e GF_SERVER_ADDR=127.0.0.1 \

--- a/imageroot/systemd/user/prometheus.service
+++ b/imageroot/systemd/user/prometheus.service
@@ -7,8 +7,8 @@ Description=Prometheus server
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/prometheus.pid %t/prometheus.ctr-id
 ExecStartPre=/usr/local/bin/runagent provision-prometheus
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --network=host \
-    --volume=%S/state/prometheus.yml:/prometheus/prometheus.yml:z \
+    --volume=%E/state/prometheus.yml:/prometheus/prometheus.yml:z \
     --volume=./prometheus.d/:/prometheus/prometheus.d/:z \
     --volume=./rules.d/:/prometheus/rules.d/:z \
     --volume=prometheus-data:/prometheus:z \


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host